### PR TITLE
feat: extract info from generated id, provide compress form of ID, up…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,15 @@ Add manual config to `application.conf`:
 ```hocon
 snowflake4s {
   twitter { # using Twitter's algorithm
-    machine_id = 1 # from 1 to 31
-    worker_id = 1 # from 1 to 31 
+    machine_id = 1 # from 0 to 31
+    machine_id = ${?SNOWFLAKE4S_MACHINE_ID} # Set machine id from env
+    
+    worker_id = 1 # from 0 to 31 
+    worker_id = ${?SNOWFLAKE4S_WORKER_ID} # Set worker id from env
+
+    # Default Epoch is October 18, 1989, 16:53:40 UTC
+    # You can change to a different epoch by below setting
+    # epoch = "2021-01-01T00:00:00Z" 
   }
 }
 ```
@@ -28,6 +35,13 @@ to generate id:
 val IdGenerator = Snowflake4s.generator
 
 val id = IdGenerator.generate()
+id.toBase62 // 52nlGCNq00n
+id.toLong // 4234436103643992065
+
+// Revert info from saved Id
+
+val id = Id.fromBase62("52nlGCNq00n")
+println(id.workerId) // 5
 ```
 
 You also could bulk generate 10 ids with the following snippet: 

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,9 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       "com.typesafe" % "config" % "1.3.1",
       "com.google.inject" % "guice" % "4.1.0",
-      "net.codingwell" %% "scala-guice" % "4.2.9"
+      "net.codingwell" %% "scala-guice" % "4.2.9",
+      "com.github.tototoshi" % "scala-base62_2.10" % "0.1.0",
+      "org.scalatest" %% "scalatest" % "3.2.10" % Test
     )
   )
   .settings(

--- a/src/main/scala/com/septech/snowflake4s/Encoding.scala
+++ b/src/main/scala/com/septech/snowflake4s/Encoding.scala
@@ -1,0 +1,51 @@
+package com.septech.snowflake4s
+
+import java.time.{Instant, LocalDateTime, Month, ZoneId, ZonedDateTime}
+
+private [snowflake4s] object Encoding {
+
+  /**
+    *  This is a Custom Epoch, mean for reference time: October 18, 1989, 16:53:40 UTC -
+    *  The date of Galileo Spacecraft was launched to explored Jupiter and its moon from Kennedy Space Center, Florida, US.
+    *
+    *  Galileo is also the name used for the satellite navigation system of the European Union.
+    *  It uses 22 August 1999 for Epoch instead of the Unix Epoch(January 1st, 1970).
+    */
+  final val zoneId = ZoneId.of("US/Eastern")
+  final val GALILEO_LAUNCHED_DATETIME: ZonedDateTime =
+    LocalDateTime.of(1989, Month.OCTOBER, 18, 16, 53, 40).atZone(zoneId)
+
+  final val EPOCH: Long = Option(System.getProperty("snowflake4s.twitter.epoch"))
+    .map(ZonedDateTime.parse)
+    .map(_.toInstant.toEpochMilli)
+    .getOrElse(GALILEO_LAUNCHED_DATETIME.toInstant.toEpochMilli)
+
+  final private val workerIdBits: Long = 5L
+  final private val datacenterIdBits: Long = 5L
+  final private val sequenceBits: Long = 12L
+  final private val workerIdShift: Long = sequenceBits
+  final private val machineIdShift: Long = sequenceBits + workerIdBits
+  final private val timestampLeftShift: Long = sequenceBits + workerIdBits + datacenterIdBits
+  final private val sequenceMask: Long = -1L ^ (-1L << sequenceBits)
+
+  def encode(id: Id): Long = {
+    (id.timestamp - EPOCH) << timestampLeftShift |
+      id.machineId << machineIdShift |
+      id.workerId << workerIdShift |
+      id.counter
+  }
+
+  def decode(value: Long): Id = {
+    Id(
+      value >> sequenceBits & (-1L ^ (-1L << workerIdBits)),
+      (value >> machineIdShift) & (-1L ^ (-1L << datacenterIdBits)),
+      (value >> timestampLeftShift) + EPOCH,
+      value & sequenceMask
+    )
+  }
+
+  def getDateTime(id: Id): ZonedDateTime = {
+    Instant.ofEpochMilli(id.timestamp).atZone(zoneId)
+  }
+}
+

--- a/src/main/scala/com/septech/snowflake4s/Generator.scala
+++ b/src/main/scala/com/septech/snowflake4s/Generator.scala
@@ -17,8 +17,8 @@ package com.septech.snowflake4s
 
 trait Generator {
 
-  def generate(): String
+  def generate(): Id
 
-  def bulkGenerate(batch: Int): List[String]
+  def bulkGenerate(batch: Int): List[Id]
 
 }

--- a/src/main/scala/com/septech/snowflake4s/Id.scala
+++ b/src/main/scala/com/septech/snowflake4s/Id.scala
@@ -1,0 +1,33 @@
+package com.septech.snowflake4s
+
+import java.time.ZonedDateTime
+import com.github.tototoshi.base62.Base62
+
+case class Id(workerId: Long, machineId: Long, timestamp: Long, counter: Long) {
+
+  def toLong: Long = encode
+
+  override def toString: String = encode.toString
+
+  def encode: Long =  {
+    Encoding.encode(this)
+  }
+
+  def getDate: ZonedDateTime = {
+    Encoding.getDateTime(this)
+  }
+
+  def toBase62: String = new Base62().encode(encode)
+}
+
+object Id {
+  def from(id: Long): Id = {
+    Encoding.decode(id)
+  }
+
+  def fromBase62(id: String): Id = from(new Base62().decode(id))
+
+  def next: Id = Snowflake4s.generator.generate()
+
+  def bulk(numOfIds: Int): List[Id] = Snowflake4s.generator.bulkGenerate(numOfIds)
+}

--- a/src/test/scala/com/septech/snowflake4s/Snowflake4sTest.scala
+++ b/src/test/scala/com/septech/snowflake4s/Snowflake4sTest.scala
@@ -1,0 +1,23 @@
+package com.septech.snowflake4s
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.time.{LocalDateTime, ZoneId}
+
+class Snowflake4sTest extends AnyFlatSpec {
+  it can "convert to various forms" in {
+
+    val timezone = ZoneId.of("US/Eastern")
+    val date = LocalDateTime.of(2021, 10, 15, 12, 30, 59, 127000000).atZone(timezone)
+    val timestamp = date.toInstant.toEpochMilli
+    // 1634315459127
+
+    val id = Id(1, 5, timestamp, 1)
+
+    assert(Id.from(4234436103643992065L) == id)
+    assert(id.toLong == 4234436103643992065L)
+    assert(id.getDate == date)
+    assert(id.toBase62 == "52nlGCNq00n")
+    assert(Id.fromBase62("52nlGCNq00n") == id)
+  }
+}


### PR DESCRIPTION
## Added
- Extract info from generated id
- Compressed form for generated ID
- Able to setting Epoch
- Intergrate scalatest
- Update README
- Add a few ID's methods `Id.next` is alias for `Snowflake4s.generator.generate`, `Id.bulk()` is alias for `Snowflake4s.generator.bulkGenerate`